### PR TITLE
Paginate memberships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules
 .env
 ToDo.private
 
-# Test version of sample
+# Test version of sample and private tests
 example1.js
+maxStartupSpace.js
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The primary change in this implementation is that it is based on the [webex-jssd
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
+Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+
 
 ## [Version History](./docs/version-history.md)
 
@@ -244,7 +246,7 @@ The [MongoStore](#MongoStore) (and potentially other stores that use a persisten
 
 See [MongoStore](#MongoStore), for details on how to configure this storage adaptor.
 
-The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./docs/contributing.md)!
+The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
 
 
 ## Bot Accounts
@@ -411,7 +413,7 @@ Options Object
 | token | <code>string</code> |  | Webex Token. |
 | [webhookUrl] | <code>string</code> |  | URL that is used for Webex API to send callbacks.  If not set events are received via websocket |
 | [webhookSecret] | <code>string</code> |  | If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set. |
-| [maxStartupSpaces] | <code>number</code> | <code>100</code> | If specified, the maximum number of spaces with our bot that the framework will discover during startup.           Max value for this parameter is 1000.  Setting this emulates the legacy flint startup behavior, otherwise          bots are discovered "just in time" if they are messaged in existing spaces or added to new spaces, which is closer         to the way webex teams clients also work.  See the [Spawn Event docs](#"spawn") to discover how to handle them differently |
+| [maxStartupSpaces] | <code>number</code> |  | If specified, the maximum number of spaces with our bot that the framework will discover during startup.           If not specified the framework will attempt to discover all the spaces the framework's identity is in and create ("spawn") for all of         them before emitting an "initiatialized mesage".  For popular bots that belog to hundreds or thousands of spaces, this can result         in long startup times by default. Setting this to a number (ie: 100) will limit the number of bots spawned bfore initialization.         Bots that are driven by external events and rely on logic that checks if an appropriate bot object exists before sending a notification          should not modify the default.  Bots that are driven primarily by webex user commands to the bot may         set this to 0 or any positive number to faciliate a faster startup.  After initialization new bot objects are created ("spawned")         when the bot is added to a new space or if the framework receives messages from existing spaces that it did not discover during initialization.         In the case of these "late discoveries", bots objects are spawned "just in time".  This behavior is similar to the way         the webex teams clients also works.  See the [Spawn Event docs](#"spawn") to discover how to handle the different types of spawn events. |
 | [messageFormat] | <code>string</code> | <code>&quot;text&quot;</code> | Default Webex message format to use with bot.say(). |
 | [initBotStorageData] | <code>object</code> | <code>{}</code> | Initial data for new bots to put into storage. |
 | [id] | <code>string</code> | <code>&quot;random&quot;</code> | The id this instance of Framework uses. |

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The [MongoStore](#MongoStore) (and potentially other stores that use a persisten
 
 See [MongoStore](#MongoStore), for details on how to configure this storage adaptor.
 
-The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
+The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./docs/contributing.md)!
 
 
 ## Bot Accounts

--- a/docs/header.md
+++ b/docs/header.md
@@ -8,6 +8,8 @@ The primary change in this implementation is that it is based on the [webex-jssd
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
+Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+
 
 ## [Version History](./docs/version-history.md)
 

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,7 +1,7 @@
 ## v 1.1.0
-* Modified `maxStartupSpaces` configuration option behavior.   When not set the framework will attempt to discover all the spaces the bot (or framework's user), generating a bot object and emitting a "spawn" event for each one before emitting an "initialized" event. Developers may set this object to any integer greater than zero to speed up start time, but this should only be used in cases where the bot logic is primarily driven by commands from Webex users, as opposed to event notification bots which may rely on logic to determine if a bot object exists before sending the appropriate event.
+* Modified `maxStartupSpaces` configuration option behavior.   When not set the framework will attempt to discover all the spaces the bot (or framework's user) is in, generating a bot object and emitting a "spawn" event for each one before emitting an "initialized" event. Developers may set this config option to any integer greater than zero to speed up start time, but this should only be used in cases where the bot logic is primarily driven by commands from Webex users, as opposed to event notification bots which may rely on logic to determine if a bot object exists before sending the appropriate event.
 *  This is a change in behavior from when this parameter was introduced in v0.7.0, where the default value was 100.  This change was made so that developers must explicilty choose not to spawn all bot objects during intialization.
-* Updated startup logic to properly paginate through all the response to the list memberships API call in order to discover all possible spaces.
+* Updated startup logic to properly paginate through all the responses to the list memberships API call in order to discover all possible spaces.
 
  
 ## v 1.0.5

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,8 @@
+## v 1.1.0
+* Modified `maxStartupSpaces` parameter behavior.   When not set the framework will attempt to discover all the spaces the bot (or framework's user), generating a bot object and emitting a "spawn" event for each one before emitting an "initialized" event. Developers may set this object to any integer greater than zero to speed up start time, but this should only be used in cases where the bot logic is primarily driven by commands from Webex users, as opposed to event notification bots which may rely on logic to determine if a bot object exists before sending the appropriate event.
+*  This is a change in behavior from when this parameter was introduced in v0.7.0, where the default value was 100.  This change was made so that developers must explicilty choose not to spawn all bot objects during intialization.
+
+ 
 ## v 1.0.5
 * Fix in webhook cleanup logic on framework.stop()
  

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,6 +1,7 @@
 ## v 1.1.0
-* Modified `maxStartupSpaces` parameter behavior.   When not set the framework will attempt to discover all the spaces the bot (or framework's user), generating a bot object and emitting a "spawn" event for each one before emitting an "initialized" event. Developers may set this object to any integer greater than zero to speed up start time, but this should only be used in cases where the bot logic is primarily driven by commands from Webex users, as opposed to event notification bots which may rely on logic to determine if a bot object exists before sending the appropriate event.
+* Modified `maxStartupSpaces` configuration option behavior.   When not set the framework will attempt to discover all the spaces the bot (or framework's user), generating a bot object and emitting a "spawn" event for each one before emitting an "initialized" event. Developers may set this object to any integer greater than zero to speed up start time, but this should only be used in cases where the bot logic is primarily driven by commands from Webex users, as opposed to event notification bots which may rely on logic to determine if a bot object exists before sending the appropriate event.
 *  This is a change in behavior from when this parameter was introduced in v0.7.0, where the default value was 100.  This change was made so that developers must explicilty choose not to spawn all bot objects during intialization.
+* Updated startup logic to properly paginate through all the response to the list memberships API call in order to discover all possible spaces.
 
  
 ## v 1.0.5

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -51,10 +51,16 @@ function Framework(options) {
    * @property {string} token - Webex Token.
    * @property {string} [webhookUrl] - URL that is used for Webex API to send callbacks.  If not set events are received via websocket
    * @property {string} [webhookSecret] - If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set.
-   * @property {number}[maxStartupSpaces=100] - If specified, the maximum number of spaces with our bot that the framework will discover during startup.  
-        Max value for this parameter is 1000.  Setting this emulates the legacy flint startup behavior, otherwise 
-        bots are discovered "just in time" if they are messaged in existing spaces or added to new spaces, which is closer
-        to the way webex teams clients also work.  See the [Spawn Event docs](#"spawn") to discover how to handle them differently
+   * @property {number}[maxStartupSpaces] - If specified, the maximum number of spaces with our bot that the framework will discover during startup.  
+        If not specified the framework will attempt to discover all the spaces the framework's identity is in and "spawn" a bot object for all of
+        them before emitting an "initiatialized" event.  For popular bots that belog to hundreds or thousands of spaces, this can result
+        in long startup times. Setting this to a number (ie: 100) will limit the number of bots spawned before initialization.
+        Bots that are driven by external events and rely on logic that checks if an appropriate bot object exists before sending a notification 
+        should not modify the default.  Bots that are driven primarily by webex user commands to the bot may
+        set this to 0 or any positive number to facilitate a faster startup.  After initialization new bot objects are created ("spawned")
+        when the bot is added to a new space or, if the framework receives events in existing spaces that it did not discover during initialization.
+        In the case of these "late discoveries", bots objects are spawned "just in time".  This behavior is similar to the way
+        the webex teams clients work.  See the [Spawn Event docs](#"spawn") to discover how to handle the different types of spawn events.
    * @property {string} [messageFormat=text] - Default Webex message format to use with bot.say().
    * @property {object} [initBotStorageData={}] - Initial data for new bots to put into storage. 
    * @property {string} [id=random] - The id this instance of Framework uses.
@@ -99,11 +105,11 @@ function Framework(options) {
   this.initBotStorageData = (typeof options.initBotStorageData === 'object') ? options.initBotStorageData : {};
 
   // Check how many spaces to discover upon startup
-  if ((typeof options.maxStartupSpaces === 'number') &&
-    (options.maxStartupSpaces >= 0) && (options.maxStartupSpaces <= 1000)) {
+  if ((typeof options.maxStartupSpaces === 'number') && (options.maxStartupSpaces >= 0)) {
     this.maxStartupSpaces = options.maxStartupSpaces;
-  } else {
-    this.maxStartupSpaces = 100;
+  } else if (options.hasOwnProperty('maxStartupSpaces')) {
+    console.error(`Invalid configuration option for "maxStartupSpaces": "${options.maxStartupSpaces}". ` +
+      `Ignoring and attempting to spawn all existing bots prior to initialization.`)
   }
 
   // register internal events
@@ -297,7 +303,7 @@ Framework.prototype.start = function () {
     }
 
     // init webex
-    this.webex = new Webex({ credentials: this.options.token });
+    this.webex = new Webex({credentials: this.options.token});
 
     // determine bot identity
     return this.webex.people.get('me')
@@ -420,26 +426,45 @@ Framework.prototype.start = function () {
  */
 Framework.prototype.initialize = function () {
   // spawn bots in existing rooms at startup
-  if (this.maxStartupSpaces) {
-    return this.webex.memberships.list(
-      { max: this.maxStartupSpaces }
-    )
-      .then(memberships => {
+  if (this.maxStartupSpaces != 0) {
+    var batchSize = 1000;  // max payload for list memberships
+    if ((this.hasOwnProperty('maxStartupSpaces')) && (this.maxStartupSpaces < 1000)) {
+      batchSize = this.maxStartupSpaces;
+    }
 
-        // create batch
-        var batch = _.map(memberships.items, m => {
-          return () => this.spawn(m);
-        });
+    return this.webex.memberships.list({max: batchSize})
+      .then((memberships) => {
+        let self = this;
+        var spawn_promises = [];
 
-        // run batch
-        return sequence(batch)
-          .then(() => when(true))
-          .catch(err => {
-            this.debug(err.stack);
-            return when(true);
-          });
+        return (async function f(page) {
+          let memberships = page.items;
+          if ((self.hasOwnProperty('maxStartupSpaces')) &&
+            (spawn_promises.length + memberships.length > self.maxStartupSpaces)) {
+            // remove any extras beyond what we need to reach maxStartupSpaces
+            memberships.splice(
+              self.maxStartupSpaces - spawn_promises.length,
+              memberships.length);
+          }
+          // Build a call to spawn a bot for each membership...
+          spawn_promises = spawn_promises.concat(_.map(memberships, m => {
+            return () => self.spawn(m);
+          }));
+
+          if ((page.hasNext()) && (spawn_promises.length < self.maxStartupSpaces)) {
+            // We got a paginated response and need to get another batch...
+            return page.next().then(f);
+          }
+
+          // Process all the spawn requests
+          return sequence(spawn_promises)
+            .then(() => when(true))
+            .catch(err => {
+              self.debug(err.stack);
+              return when(true);
+            });
+        }(memberships));
       })
-
       .then(() => {
         /**
          * Framework initialized event.
@@ -451,7 +476,6 @@ Framework.prototype.initialize = function () {
         this.initialized = true;
         return when(true);
       });
-
   } else {
     this.emit('initialized', this.id);
     this.initialized = true;
@@ -604,7 +628,7 @@ Framework.prototype.getTrigger = function (type, triggerObject) {
  * @returns {Promise.<Person>}
  */
 Framework.prototype.getPersonByEmail = function (personEmail) {
-  return this.webex.people.list({ email: personEmail })
+  return this.webex.people.list({email: personEmail})
     .then(people => {
       let personList = people.items;
       let numPeople = personList.length;
@@ -1337,10 +1361,10 @@ Framework.prototype.spawn = function (membership, actorId) {
       // if direct, set recipient
       if (newBot.isDirect) {
         let botId = this.person.id;
-        return this.webex.memberships.list({ roomId: roomId })
+        return this.webex.memberships.list({roomId: roomId})
           .then((memberships) => {
             // remove bot membership from room memberships
-            let otherMembers = _.reject(memberships.items, { personId: botId });
+            let otherMembers = _.reject(memberships.items, {personId: botId});
             // remaining membership is the other user in the space
             newBot.isDirectTo = otherMembers[0].personEmail;
             return when(newBot);
@@ -1396,17 +1420,19 @@ Framework.prototype.spawn = function (membership, actorId) {
        *
        * @example
        * // DM the user who added bot to a group space
-       * framework.on('spawn', function(bot, flintId, addedBy) {
+       * framework.on('spawn', function(bot, flintId, addedById) {
        *     if (!addedById) {
        *      // don't say anything here or your bot's spaces will get
        *      // spammed every time your server is restarted
        *      framework.debug(`Framework spawned a bot object in existing
        *         space: ${bot.room.title}`);
        *   } else {
-       *     if ((bot.room.type === 'group') && (addedBy)) {
-       *       bot.dm(addedBy, `I see you added me to the the space "${bot.room.title}", ` +
-       *         `but I am not allowed in group spaces.  We can talk here if you like.`);
-       *       bot.exit();
+       *     if ((bot.room.type === 'group') && (addedById)) {
+       *       // In this example we imagine our bot is only allowed in 1-1 spaces
+       *       // our bot creates a 1-1 with the addedBy user, and leaves the group space
+       *       bot.dm(addedById, `I see you added me to the the space "${bot.room.title}", ` +
+       *         `but I am not allowed in group spaces.  ` +
+       *         `We can talk here if you like.`).then(() => bot.exit());
        *     } else {
        *       bot.say(`Thanks for adding me to this space.  Here is what I can do...`);
        *     }
@@ -1470,7 +1496,7 @@ Framework.prototype.despawn = function (roomId, actorId) {
         }
 
         // remove bot from framework
-        this.bots = _.reject(this.bots, { 'id': bot.id });
+        this.bots = _.reject(this.bots, {'id': bot.id});
 
         return when(true);
       });
@@ -1523,12 +1549,12 @@ Framework.prototype.hears = function (phrase, action, helpText, preference) {
 
   if (typeof phrase === 'string' && action) {
     phrase = _.toLower(phrase);
-    this.lexicon.push({ 'id': id, 'phrase': phrase, 'action': action, 'helpText': helpText, 'preference': preference });
+    this.lexicon.push({'id': id, 'phrase': phrase, 'action': action, 'helpText': helpText, 'preference': preference});
     return id;
   }
 
   else if (phrase instanceof RegExp && action) {
-    this.lexicon.push({ 'id': id, 'phrase': phrase, 'action': action, 'helpText': helpText, 'preference': preference });
+    this.lexicon.push({'id': id, 'phrase': phrase, 'action': action, 'helpText': helpText, 'preference': preference});
     return id;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since some bots, like notification bot that are driven primarily by logic that is happening outside of Webex Teams rely on all the framework's bot objects being "spawned" when the events occur, I changed the default behavior of the maxStartupSpaces configuration option.  If this is not set it now defaults to finding all spaces that the bot is in.   Developers can still choose to limit it.

Also modified the startup logic so that the call to list memberships will properly iterate through paginated results in order to detect every possible space that the bot is in.