### PR TITLE
fix: remove duplicate credentials config

### DIFF
--- a/lib/framework.js
+++ b/lib/framework.js
@@ -305,7 +305,7 @@ Framework.prototype.start = function () {
         .catch((e) => console.error(`Memory storage adaptor initialization failed: ${e.message}`));
     }
 
-    let config = {credentials: this.options.token};
+    let config = {};
     // Configure the http proxy, if specified
     if (this.options.httpsProxy) {
       let httpsProxyAgent = new HttpsProxyAgent(url.parse(this.options.httpsProxy));


### PR DESCRIPTION
Having the token in the credentials config object is not expected and causes the SDK to break.