### PR TITLE
Added new accessor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ not sent due to mebership rules.  See <a href="./doc/membership-rules-readme.md"
     * [new Framework(options)](#new_Framework_new)
     * [.options](#Framework+options) : <code>object</code>
     * [.setWebexToken(token)](#Framework+setWebexToken) ⇒ <code>Promise.&lt;String&gt;</code>
+    * [.getWebexSDK()](#Framework+getWebexSDK) ⇒ <code>object</code>
     * [.stop()](#Framework+stop) ⇒ <code>Promise.&lt;Boolean&gt;</code>
     * [.start()](#Framework+start) ⇒ <code>Promise.&lt;Boolean&gt;</code>
     * [.restart()](#Framework+restart) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+    * [.getBotByRoomId(roomId)](#Framework+getBotByRoomId) ⇒ <code>object</code>
     * [.hears(phrase, action, [helpText], [preference])](#Framework+hears) ⇒ <code>String</code>
     * [.clearHears(id)](#Framework+clearHears) ⇒ <code>null</code>
     * [.showHelp([header], [footer])](#Framework+showHelp) ⇒ <code>String</code>
@@ -477,6 +479,25 @@ framework.setWebexToken('Tm90aGluZyB0byBzZWUgaGVyZS4uLiBNb3ZlIGFsb25nLi4u')
      console.log('token updated to: ' + token);
   });
 ```
+<a name="Framework+getWebexSDK"></a>
+
+### framework.getWebexSDK() ⇒ <code>object</code>
+Accessor for Webex SDK instance
+
+Access SDK functionality described in [SDK Reference](https://developer.webex.com/docs/sdks/browser#sdk-api-reference)
+
+**Kind**: instance method of [<code>Framework</code>](#Framework)  
+**Returns**: <code>object</code> - - Framework's Webex SDK instance  
+**Example**  
+```js
+let webex = framework.getWebexSDK();
+webex.people.get(me)
+  .then(person => {
+    console.log('SDK instantiated by: ' + person.displayName);
+  }).catch(e => {
+    console.error('SDK failed to lookup framework user: ' + e.message);
+  });
+```
 <a name="Framework+stop"></a>
 
 ### framework.stop() ⇒ <code>Promise.&lt;Boolean&gt;</code>
@@ -506,6 +527,28 @@ Restart Framework.
 **Example**  
 ```js
 framework.restart();
+```
+<a name="Framework+getBotByRoomId"></a>
+
+### framework.getBotByRoomId(roomId) ⇒ <code>object</code>
+Get bot object associated with roomId.
+Returns null if no object exists
+
+**Kind**: instance method of [<code>Framework</code>](#Framework)  
+**Returns**: <code>object</code> - - found bot object or null  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| roomId | <code>string</code> | id of room to search for |
+
+**Example**  
+```js
+let bot = framework.getBotByRoomId(roomId);
+if (bot) {
+  bot.say('Hi, I\'m the bot in this room!');
+} else {
+  console.log('Could not find bot for room ID: ' + roomId);
+}
 ```
 <a name="Framework+hears"></a>
 
@@ -693,6 +736,7 @@ before emitting and event
 * [Bot](#Bot)
     * [new Bot(framework, options, webex)](#new_Bot_new)
     * [.exit()](#Bot+exit) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+    * [.getWebexSDK()](#Bot+getWebexSDK) ⇒ <code>object</code>
     * [.add(email(s), [moderator])](#Bot+add) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.remove(email(s))](#Bot+remove) ⇒ <code>Promise.&lt;Array&gt;</code>
     * [.getModerators()](#Bot+getModerators) ⇒ <code>Promise.&lt;Array&gt;</code>
@@ -736,6 +780,28 @@ Instructs Bot to exit from room.
 **Example**  
 ```js
 bot.exit();
+```
+<a name="Bot+getWebexSDK"></a>
+
+### bot.getWebexSDK() ⇒ <code>object</code>
+Accessor for Webex SDK instance
+
+This is a convenience and returns the same shared Webex SDK instance 
+that is returned by a call to framework.getWebexSDK()
+
+Access SDK functionality described in [SDK Reference](https://developer.webex.com/docs/sdks/browser#sdk-api-reference)
+
+**Kind**: instance method of [<code>Bot</code>](#Bot)  
+**Returns**: <code>object</code> - - Bot's Webex SDK instance  
+**Example**  
+```js
+let webex = bot.getWebexSDK();
+webex.people.get(me)
+  .then(person => {
+    console.log('SDK instantiated by: ' + person.displayName);
+  }).catch(e => {
+    console.error('SDK failed to lookup framework user: ' + e.message);
+  });
 ```
 <a name="Bot+add"></a>
 

--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -39,21 +39,21 @@ Not all of the functionality in flint has been migrated to the new framework.  A
 
 * Flint exposed many functions that were primiarly thin wrappers around functionality that is natively exposed via the webex SDK.  Since we wish to promote the understanding and use of the SDK these have mostly been removed. The following flint fucntions are NOT exposed by our famework:
   * parseFile(message) -- to access files simply GET the URL(s) in the attachment field of a message.
-  * getRooms() -- call framework.webex.rooms.list()
-  * getRoom(roomId) -- call framework.webex.rooms.get(roomId)
-  * getTeams() -- call framework.webex.teams.list()
-  * getTeam(teamId) -- call framework.webex.teams.get(teamId)
-  * getTeamRooms(teamId) -- call framework.webex.rooms.get({teamId: teamId})
-  * getPerson(personId) -- call webex.people.get(personId);
-  * getMessage(messageId) -- call webex.messages.get(messageId)
-  * getFiles(messageId) -- call webex.messages.get(messageId) to get message and then to access files simply GET the URL(s) in the attachment field of a message.
-  * getMembership(membershipId) -- call webex.memberships.get(membershipId)
-  * getMemberships(roomId) -- call webex.memberships.list({ roomId: roomId })
-  * getTeamMembership(teamMembershipId) -- call webex.teamMembership.get(teamMembershipId)
-  * getTeamMemberships(teamId) -- call webex.teamMemberships.list({ teamId: teamId })
-  * getWebhook(webhookId) -- call webex.webhooks.get(webhookId)
-  * getWebhooks() -- call webex.webhooks.list()
-  * getAttachmentAction(attachmentActionId) -- call webex.attachmentActions.get(attachmentActionId);
+  * getRooms() -- call framework.getWebexSDK().rooms.list()
+  * getRoom(roomId) -- call framework.getWebexSDK().rooms.get(roomId)
+  * getTeams() -- call framework.getWebexSDK().teams.list()
+  * getTeam(teamId) -- call framework.getWebexSDK().teams.get(teamId)
+  * getTeamRooms(teamId) -- call framework.getWebexSDK().rooms.get({teamId: teamId})
+  * getPerson(personId) -- call framework.getWebexSDK().people.get(personId);
+  * getMessage(messageId) -- call framework.getWebexSDK().messages.get(messageId)
+  * getFiles(messageId) -- call framework.getWebexSDK().messages.get(messageId) to get message and then to access files simply GET the URL(s) in the attachment field of a message.
+  * getMembership(membershipId) -- call framework.getWebexSDK().memberships.get(membershipId)
+  * getMemberships(roomId) -- call framework.getWebexSDK().memberships.list({ roomId: roomId })
+  * getTeamMembership(teamMembershipId) -- call framework.getWebexSDK().teamMembership.get(teamMembershipId)
+  * getTeamMemberships(teamId) -- call framework.getWebexSDK().teamMemberships.list({ teamId: teamId })
+  * getWebhook(webhookId) -- call framework.getWebexSDK().webhooks.get(webhookId)
+  * getWebhooks() -- call framework.getWebexSDK().webhooks.list()
+  * getAttachmentAction(attachmentActionId) -- call framework.getWebexSDK().attachmentActions.get(attachmentActionId);
 
 * Bot exposed some functions for uploading file streams, that that were implemented by calling the webex APIs directly.  Some of these have been removed or simplified in favor of leveraging the native webex sdk functionality to support this.
   * say() -- this function has not changed and provides an optional mechanism for providing URL based file attachments
@@ -127,10 +127,10 @@ For developer's who are porting existing flint based bots to this framework the 
 | active        | active       | Bot active state                             |                                                              |
 | person        | --           | Bot Person Object                            | Availabile as bot.framework.person                         |
 | email         | --           | Bot email                                    | Availabile as bot.framework.person.emails[0]                                   | 
-| team          | --           | Bot team object                              | This object is seldom used and creating it slows down spawning a bot.  Apps that want it can check if `bot.room.teamId` exists and if so call `bot.webex.teams.get(bot.room.teamId)`       |
+| team          | --           | Bot team object                              | This object is seldom used and creating it slows down spawning a bot.  Apps that want it can check if `bot.room.teamId` exists and if so call `bot.getWebexSDK().teams.get(bot.room.teamId)`       |
 | room          | room         | Bot room object                              | Now is standard webex room object                            |
 | membership    | membership   | Bot membership object                        | Standard Webex Teams membership object for bot               |
-| memberships   | memberships  | All memberships for bot's space              | This array is seldom used.  Creating it slows down the initial bot spawn, and keeping it "current" requires periodic "refresh" calls to the platform.  Apps that want to inspect room memberships can instead call `bot.webex.memberships.list({roomId: bot.room.id})` at the time the data is needed.  The response is a standard Webex response and the members will be in an array called `items`.
+| memberships   | memberships  | All memberships for bot's space              | This array is seldom used.  Creating it slows down the initial bot spawn, and keeping it "current" requires periodic "refresh" calls to the platform.  Apps that want to inspect room memberships can instead call `bot.getWebexSDK().memberships.list({roomId: bot.room.id})` at the time the data is needed.  The response is a standard Webex response and the members will be in an array called `items`.
 |
 | isLocked      | isLocked     | If bot's space is locked                     |                                                              |
 | isModerator   | isModerator  | If bot is a moderator                        |                                                              |

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,7 @@
+## v 2.1.0
+* Added new accessor methods [framework.getWebexSDK()](../README.md#Framework+getWebexSDK) and [bot.getWebexSDK()](../README.md#Bot+getWebexSDK) to allow developers to access the framework's underlying Webex Javascript SDK instance which can be used to call any [JSSDK method](https://webex.github.io/webex-js-sdk/api/). Note that there is a single webex SDK instance used by the framework.  The bot accessor method is simply a convenience, both accessors return the same object, and the same object will be returned when this accessor is called on any of the frmaework's bot objects.
+* Added [framework.getBotByRoomId()](../README.md#Framework+getBotByRoomId) which allows developers to discover the bot object associated with a particular room.
+
 ## v 2.0.0
 * Added [Membership Rules](./membership-rules-readme.md) configuration options restrict bot interactions to spaces that are exclusively populated by users with email domains specified in a restricted to domain list.   Beta Mode further restricts bot interaction to only spaces where specific named users are present.
 * Added bot.sayWithLocalFiles

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -175,6 +175,31 @@ Bot.prototype.exit = function () {
 };
 
 /**
+ * Accessor for Webex SDK instance
+ * 
+ * This is a convenience and returns the same shared Webex SDK instance 
+ * that is returned by a call to framework.getWebexSDK()
+ *
+ * Access SDK functionality described in [SDK Reference](https://developer.webex.com/docs/sdks/browser#sdk-api-reference)
+ * 
+ * @function
+ * @returns {object} - Bot's Webex SDK instance
+ *
+ * @example
+ * let webex = bot.getWebexSDK();
+ * webex.people.get(me)
+ *   .then(person => {
+ *     console.log('SDK instantiated by: ' + person.displayName);
+ *   }).catch(e => {
+ *     console.error('SDK failed to lookup framework user: ' + e.message);
+ *   });
+ */
+Bot.prototype.getWebexSDK = function () {
+  return this.webex;
+};
+
+
+/**
  * Instructs Bot to add person(s) to room.
  *
  * @function

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -247,6 +247,29 @@ Framework.prototype.testWebexToken = function (token) {
 };
 
 /**
+ * Accessor for Webex SDK instance
+ *
+ * Access SDK functionality described in [SDK Reference](https://developer.webex.com/docs/sdks/browser#sdk-api-reference)
+ * 
+ * @function
+ * @memberof Framework
+ * @returns {object} - Framework's Webex SDK instance
+ *
+ * @example
+ * let webex = framework.getWebexSDK();
+ * webex.people.get(me)
+ *   .then(person => {
+ *     console.log('SDK instantiated by: ' + person.displayName);
+ *   }).catch(e => {
+ *     console.error('SDK failed to lookup framework user: ' + e.message);
+ *   });
+ */
+Framework.prototype.getWebexSDK = function () {
+  return this.webex;
+};
+
+
+/**
  * Stop Framework.
  *
  * @function
@@ -737,6 +760,26 @@ Framework.prototype.getPersonDomain = function (person) {
   }
 };
 
+/**
+ * Get bot object associated with roomId.
+ * Returns null if no object exists
+ * 
+ * @function
+ * @memberof Framework
+ * @param {string} roomId - id of room to search for
+ * @returns {object} - found bot object or null
+ *
+ * @example
+ * let bot = framework.getBotByRoomId(roomId);
+ * if (bot) {
+ *   bot.say('Hi, I\'m the bot in this room!');
+ * } else {
+ *   console.log('Could not find bot for room ID: ' + roomId);
+ * }
+ */
+Framework.prototype.getBotByRoomId = function (roomId) {
+  return _.find(this.bots, bot => bot.room.id === roomId); 
+};
 
 /**
  * Process a Room create event.
@@ -2025,16 +2068,16 @@ Framework.prototype.emitBoth = function (event, bot, ...args) {
 };
 
 /**
- * Helper futionn to determin if a bot object already exists in a space
+ * Helper function to determine if a bot object already exists in a space
  *
  * @function
  * @memberof Framework
  * @private
  * @param {String} roomId - Id of room to lookup
- * @returns {Promise}
+ * @returns {object} - found bot object or null
  */
 Framework.prototype.findBotObjectInRoom = function (roomId) {
-  var bot = _.find(this.bots, bot => bot.room.id === roomId);
+  var bot = _.find(this.bots, bot => bot.room.id === roomId); 
   if ((!bot) & ("membershipRules" in this)) {
     bot = _.find(this.inactiveBots, bot => bot.room.id === roomId);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Added new accessor methods [framework.getWebexSDK()](../README.md#Framework+getWebexSDK) and [bot.getWebexSDK()](../README.md#Bot+getWebexSDK) to allow developers to access the framework's underlying Webex Javascript SDK instance which can be used to call any [JSSDK method](https://webex.github.io/webex-js-sdk/api/). Note that there is a single webex SDK instance used by the framework.  The bot accessor method is simply a convenience, both accessors return the same object, and the same object will be returned when this accessor is called on any of the frmaework's bot objects.
* Added [framework.getBotByRoomId()](../README.md#Framework+getBotByRoomId) which allows developers to discover the bot object associated with a particular room.
